### PR TITLE
Allow to wiremock API responses instead of using sandbox

### DIFF
--- a/sdk/src/main/java/com/uber/sdk/rides/auth/OAuth2Credentials.java
+++ b/sdk/src/main/java/com/uber/sdk/rides/auth/OAuth2Credentials.java
@@ -22,7 +22,12 @@
 
 package com.uber.sdk.rides.auth;
 
-import com.google.api.client.auth.oauth2.*;
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
+import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;

--- a/sdk/src/main/java/com/uber/sdk/rides/client/SessionConfiguration.java
+++ b/sdk/src/main/java/com/uber/sdk/rides/client/SessionConfiguration.java
@@ -24,12 +24,11 @@ package com.uber.sdk.rides.client;
 
 import com.uber.sdk.core.auth.Scope;
 
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
-
-import javax.annotation.Nonnull;
 
 import static com.uber.sdk.rides.client.SessionConfiguration.EndpointRegion.WORLD;
 import static com.uber.sdk.rides.client.utils.Preconditions.checkNotNull;
@@ -78,6 +77,7 @@ public class SessionConfiguration implements Serializable {
         private Collection<Scope> scopes;
         private Collection<String> customScopes;
         private Locale locale;
+        private String baseUrl;
 
         /**
          * The Uber API requires a registered clientId to be sent along with API requests and Deeplinks.
@@ -145,6 +145,11 @@ public class SessionConfiguration implements Serializable {
          */
         public Builder setEnvironment(@Nonnull Environment environment) {
             this.environment = environment;
+            return this;
+        }
+
+        public Builder setBaseUrl(@Nonnull String url) {
+            this.baseUrl = url;
             return this;
         }
 
@@ -218,6 +223,7 @@ public class SessionConfiguration implements Serializable {
                     redirectUri,
                     region,
                     environment,
+                    baseUrl,
                     scopes,
                     customScopes,
                     locale);
@@ -230,6 +236,7 @@ public class SessionConfiguration implements Serializable {
     private final String redirectUri;
     private final EndpointRegion region;
     private final Environment environment;
+    private final String baseUrl;
     private final Collection<Scope> scopes;
     private final Collection<String> customScopes;
     private final Locale locale;
@@ -240,6 +247,7 @@ public class SessionConfiguration implements Serializable {
                                    @Nonnull String redirectUri,
                                    @Nonnull EndpointRegion region,
                                    @Nonnull Environment environment,
+                                   String baseUrl,
                                    @Nonnull Collection<Scope> scopes,
                                    @Nonnull Collection<String> customScopes,
                                    @Nonnull Locale locale) {
@@ -249,6 +257,7 @@ public class SessionConfiguration implements Serializable {
         this.redirectUri = redirectUri;
         this.region = region;
         this.environment = environment;
+        this.baseUrl = baseUrl;
         this.scopes = scopes;
         this.customScopes = customScopes;
         this.locale = locale;
@@ -314,7 +323,9 @@ public class SessionConfiguration implements Serializable {
      */
     @Nonnull
     public String getEndpointHost() {
-        return String.format("https://%s.%s", environment.subDomain, region.domain);
+        return baseUrl != null ?
+                baseUrl :
+                String.format("https://%s.%s", environment.subDomain, region.domain);
     }
 
     /**

--- a/sdk/src/test/java/com/uber/sdk/rides/client/SessionConfigurationTest.java
+++ b/sdk/src/test/java/com/uber/sdk/rides/client/SessionConfigurationTest.java
@@ -23,7 +23,6 @@
 package com.uber.sdk.rides.client;
 
 import com.uber.sdk.core.auth.Scope;
-
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -156,5 +155,14 @@ public class SessionConfigurationTest {
                 .setEndpointRegion(CHINA)
                 .build();
         assertEquals("https://sandbox-api.uber.com.cn", sessionConfig.getEndpointHost());
+    }
+
+    @Test
+    public void buildSession_whenCustomEnvUrl_shouldGiveCustomEndpointHost() throws Exception {
+        SessionConfiguration sessionConfig = new SessionConfiguration.Builder()
+                .setBaseUrl("http://localhost:8888/uber-mock")
+                .setClientId("clientId")
+                .build();
+        assertEquals("http://localhost:8888/uber-mock", sessionConfig.getEndpointHost());
     }
 }

--- a/sdk/src/test/java/com/uber/sdk/rides/client/services/RidesServiceTest.java
+++ b/sdk/src/test/java/com/uber/sdk/rides/client/services/RidesServiceTest.java
@@ -1,17 +1,15 @@
 package com.uber.sdk.rides.client.services;
 
-import com.squareup.moshi.Moshi;
 import com.uber.sdk.WireMockTest;
+import com.uber.sdk.rides.client.ServerTokenSession;
+import com.uber.sdk.rides.client.SessionConfiguration;
+import com.uber.sdk.rides.client.UberRidesApi;
 import com.uber.sdk.rides.client.model.Product;
 import com.uber.sdk.rides.client.model.Ride;
 import com.uber.sdk.rides.client.model.RideEstimate;
 import com.uber.sdk.rides.client.model.RideRequestParameters;
-import okhttp3.OkHttpClient;
-import okhttp3.logging.HttpLoggingInterceptor;
 import org.junit.Before;
 import org.junit.Test;
-import retrofit2.Retrofit;
-import retrofit2.converter.moshi.MoshiConverterFactory;
 
 import java.util.List;
 
@@ -35,16 +33,12 @@ public class RidesServiceTest extends WireMockTest {
     @Before
     public void setUp() throws Exception {
 
-        service = new Retrofit.Builder()
-                .addConverterFactory(MoshiConverterFactory.create(new Moshi.Builder().build()))
-                .client(new OkHttpClient.Builder()
-                        .addInterceptor(new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
-                        .build())
-                .baseUrl("http://localhost:" + wireMockRule.port())
-                .build()
-                .create(RidesService.class);
+        SessionConfiguration sessionConfig = new SessionConfiguration.Builder()
+            .setClientId("clientId")
+            .setBaseUrl("http://localhost:" + wireMockRule.port()).build();
+        ServerTokenSession session = new ServerTokenSession(sessionConfig);
 
-
+        service = UberRidesApi.with(session).build().createService();
     }
 
     private static RideRequestParameters createRideRequest() {


### PR DESCRIPTION
## Motivation

We extensively use Rides API and have about 30 integration tests with various API interactions. When using sandbox our build took about 8 minutes to finish, so we decided to mock Rides API with WireMock. Now the build takes less than 3 minutes ;)

## Details

Instead of setting Environment we added a baseUrl property which is used to build endpointHost if present.