### PR TITLE
Added token request needed for PKCE

### DIFF
--- a/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
+++ b/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
@@ -70,7 +70,11 @@ public class AuthorizationCodeGrantFlow implements TokenRequestFlow {
                 new Callback<AccessToken>() {
                     @Override
                     public void onResponse(Call<AccessToken> call, Response<AccessToken> response) {
-                        callback.onSuccess(response.body());
+                        if (response.isSuccessful()) {
+                            callback.onSuccess(response.body());
+                        } else {
+                            callback.onFailure(new AuthException("Token request failed with code " + response.code()));
+                        }
                     }
 
                     @Override

--- a/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
+++ b/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
@@ -1,0 +1,92 @@
+package com.uber.sdk.core.auth;
+
+import com.squareup.moshi.Moshi;
+import com.uber.sdk.core.auth.internal.OAuth2Service;
+import com.uber.sdk.core.auth.internal.OAuthScopesAdapter;
+import com.uber.sdk.core.auth.internal.TokenRequestFlow;
+import com.uber.sdk.core.client.SessionConfiguration;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.moshi.MoshiConverterFactory;
+
+/**
+ * Provides implementation for {@link TokenRequestFlow} where authorization code is used along with
+ * proof key code exchange mechanism to fetch oauth tokens
+ */
+public class AuthorizationCodeGrantFlow implements TokenRequestFlow {
+
+    private final static String GRANT_TYPE = "authorization_code";
+
+    private final OAuth2Service oAuth2Service;
+    private final SessionConfiguration sessionConfiguration;
+    private final String authCode;
+    private final String codeVerifier;
+
+    public AuthorizationCodeGrantFlow(
+        SessionConfiguration sessionConfiguration,
+        String authCode,
+        String codeVerifier
+    ) {
+        this(createOAuthService(sessionConfiguration.getLoginHost()),
+                sessionConfiguration,
+                authCode,
+                codeVerifier
+        );
+    }
+
+    /**
+     * This contructor is used for testing only
+     * @param ooAuth2Service
+     * @param sessionConfiguration
+     * @param authCode
+     * @param codeVerifier
+     */
+    AuthorizationCodeGrantFlow(
+            OAuth2Service ooAuth2Service,
+            SessionConfiguration sessionConfiguration,
+            String authCode,
+            String codeVerifier
+    ) {
+        this.oAuth2Service = ooAuth2Service;
+        this.sessionConfiguration = sessionConfiguration;
+        this.authCode = authCode;
+        this.codeVerifier = codeVerifier;
+    }
+
+
+
+    @Override
+    public void execute(TokenRequestFlowCallback callback) {
+        oAuth2Service.token(
+                sessionConfiguration.getClientId(),
+                codeVerifier,
+                GRANT_TYPE,
+                sessionConfiguration.getRedirectUri(),
+                authCode
+        ).enqueue(
+                new Callback<AccessToken>() {
+                    @Override
+                    public void onResponse(Call<AccessToken> call, Response<AccessToken> response) {
+                        callback.onSuccess(response.body());
+                    }
+
+                    @Override
+                    public void onFailure(Call<AccessToken> call, Throwable t) {
+                        callback.onFailure(t);
+                    }
+                }
+        );
+    }
+
+    private static OAuth2Service createOAuthService(String baseUrl) {
+        final Moshi moshi = new Moshi.Builder().add(new OAuthScopesAdapter()).build();
+        return new Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .build()
+                .create(OAuth2Service.class);
+    }
+}

--- a/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
+++ b/uber-core/src/main/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlow.java
@@ -73,7 +73,7 @@ public class AuthorizationCodeGrantFlow implements TokenRequestFlow {
                         if (response.isSuccessful()) {
                             callback.onSuccess(response.body());
                         } else {
-                            callback.onFailure(new AuthException("Token request failed with code " + response.code()));
+                            onFailure(call, new AuthException("Token request failed with code " + response.code()));
                         }
                     }
 

--- a/uber-core/src/main/java/com/uber/sdk/core/auth/internal/OAuth2Service.java
+++ b/uber-core/src/main/java/com/uber/sdk/core/auth/internal/OAuth2Service.java
@@ -34,6 +34,15 @@ public interface OAuth2Service {
     @POST("token")
     Call<AccessToken> refresh(@Field("refresh_token") String refreshToken,
                               @Field("client_id") String clientId);
+
+    @FormUrlEncoded
+    @POST("/oauth/v2/token")
+    Call<AccessToken> token(@Field("client_id") String clientId,
+                            @Field("code_verifier") String codeVerifier,
+                            @Field("grant_type") String grantType,
+                            @Field("redirect_uri") String redirectUri,
+                            @Field("code") String authCode);
+
     @FormUrlEncoded
     @POST("/oauth/v2/par")
     Call<LoginPARResponse> loginParRequest(

--- a/uber-core/src/main/java/com/uber/sdk/core/auth/internal/TokenRequestFlow.java
+++ b/uber-core/src/main/java/com/uber/sdk/core/auth/internal/TokenRequestFlow.java
@@ -1,0 +1,31 @@
+package com.uber.sdk.core.auth.internal;
+
+import com.uber.sdk.core.auth.AccessToken;
+
+/**
+ * Interface to request tokens from the backend
+ */
+public interface TokenRequestFlow {
+    /**
+     * Executes the token request
+     * @param callback Callback will be invoked when the request succeeds or errors out.
+     */
+    void execute(TokenRequestFlowCallback callback);
+
+    /**
+     * Interface to provide callback for token request result
+     */
+    interface TokenRequestFlowCallback {
+        /**
+         * Called when token request finishes successfully
+         * @param accessToken {@link AccessToken} object containing oauth tokens
+         */
+        void onSuccess(AccessToken accessToken);
+
+        /**
+         * Called when token request finishes with a failure
+         * @param error
+         */
+        void onFailure(Throwable error);
+    }
+}

--- a/uber-core/src/test/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlowTest.java
+++ b/uber-core/src/test/java/com/uber/sdk/core/auth/AuthorizationCodeGrantFlowTest.java
@@ -1,0 +1,111 @@
+package com.uber.sdk.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.uber.sdk.core.auth.internal.OAuth2Service;
+import com.uber.sdk.core.auth.internal.TokenRequestFlow;
+import com.uber.sdk.core.auth.internal.TokenRequestFlow.TokenRequestFlowCallback;
+import com.uber.sdk.core.client.SessionConfiguration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AuthorizationCodeGrantFlowTest {
+
+    @Mock private TokenRequestFlowCallback callback;
+
+    @Mock
+    OAuth2Service oAuth2Service;
+
+    @Mock
+    Call<AccessToken> accessTokenCall;
+
+    private TokenRequestFlow tokenRequestFlow;
+
+    AccessToken accessToken = new AccessToken(
+            1,
+            Arrays.asList(Scope.PROFILE),
+            "accessToken",
+            "refreshToken",
+            "Bearer"
+    );
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        SessionConfiguration sessionConfiguration =
+                new SessionConfiguration.Builder()
+                        .setClientId("clientId")
+                        .setProfileHint(
+                                new ProfileHint
+                                        .Builder()
+                                        .firstName("par")
+                                        .lastName("test")
+                                        .email("abc@gmail.com")
+                                        .phone("+11234567890")
+                                        .build()
+                        )
+                        .build();
+        tokenRequestFlow = new AuthorizationCodeGrantFlow(
+                oAuth2Service,
+                sessionConfiguration,
+                "code",
+                "verifier"
+        );
+    }
+
+    @Test
+    public void execute_whenSuccessful_shouldReturnAccessToken() {
+        Class<Callback<AccessToken>> tokenRequestFlowCallback = (Class<Callback<AccessToken>>)(Class) Callback.class;
+        ArgumentCaptor<Callback<AccessToken>> argumentCaptor = ArgumentCaptor.forClass(tokenRequestFlowCallback);
+        doNothing().when(callback).onSuccess(any());
+        when(oAuth2Service.token(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString())
+        ).thenReturn(accessTokenCall);
+        tokenRequestFlow.execute(callback);
+        verify(accessTokenCall).enqueue(argumentCaptor.capture());
+        argumentCaptor.getValue().onResponse(accessTokenCall, Response.success(accessToken));
+
+        verify(callback).onSuccess(accessToken);
+        assertThat(accessToken.getToken()).isEqualTo("accessToken");
+    }
+
+    @Test
+    public void execute_whenFailure_shouldReturnError() {
+        Class<Callback<AccessToken>> tokenRequestFlowCallback = (Class<Callback<AccessToken>>)(Class) Callback.class;
+        ArgumentCaptor<Callback<AccessToken>> argumentCaptor = ArgumentCaptor.forClass(tokenRequestFlowCallback);
+        doNothing().when(callback).onSuccess(any());
+        when(oAuth2Service.token(
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyString())
+        ).thenReturn(accessTokenCall);
+        tokenRequestFlow.execute(callback);
+        verify(accessTokenCall).enqueue(argumentCaptor.capture());
+        Throwable t = new RuntimeException("exception occurred");
+        argumentCaptor.getValue().onFailure(accessTokenCall, t);
+
+        verify(callback).onFailure(t);
+        assertThat(t.getMessage()).isEqualTo("exception occurred");
+    }
+}


### PR DESCRIPTION
Clients can use the proof key code exchange mechanism to request oauth tokens using the new added /token endpoint